### PR TITLE
fcntl fix for pyvirtualdisplay package

### DIFF
--- a/tests/requirements-test.txt
+++ b/tests/requirements-test.txt
@@ -6,3 +6,5 @@ pytest-cov
 pytest-qt
 pytest-xvfb
 tox
+pyvirtualdisplay<0.2.3; os_name == 'nt'
+pyvirtualdisplay ; os_name != 'nt'

--- a/tests/requirements-test.txt
+++ b/tests/requirements-test.txt
@@ -6,5 +6,9 @@ pytest-cov
 pytest-qt
 pytest-xvfb
 tox
+# pyvirtualdisplay package (needed by pytest-xvfb for GUI testing) introduced dependency
+# on fcntl which is causing compatibility problems on Windows
+# https://github.com/ponty/PyVirtualDisplay/commit/5c92b6e56d52be6a50c2c6942ab14287ceb14737
+# thus for Windows we decide to use older version
 pyvirtualdisplay<0.2.3; os_name == 'nt'
 pyvirtualdisplay ; os_name != 'nt'


### PR DESCRIPTION
trying to limit pyvirtualdisplay to old Windows-compatible version as 0.2.3 introduced usage of fcntl locking which is Linux specific