### PR TITLE
numpy removed from requirement list, as pytrip98 depends on it

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-numpy
 pytrip98>=2.5.6
 PyQt5<5.10

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setuptools.setup(
     ],
     package_data={'pytripgui': ['res/*', 'view/*.ui']},
     install_requires=[
-        'numpy', 'pytrip98', 'PyQt5'
+        'pytrip98', 'PyQt5'
     ],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
Fixes #255