### PR TITLE
fix setting basename while editing (#288)

### DIFF
--- a/pytripgui/app_logic/app_callbacks.py
+++ b/pytripgui/app_logic/app_callbacks.py
@@ -154,7 +154,8 @@ class AppCallback:
             self.parent_gui.show_info(*InfoMessages["loadCtxVdx"])
             return False
 
-        item.data.basename = patient.data.name
+        if not item.data.basename:
+            item.data.basename = patient.data.name
 
         view = PlanQtView(self.parent_gui.ui)
 


### PR DESCRIPTION
item basename was overwritten by patient name in edit function, added simple if and now it works nicely

closes #288 