### PR TITLE
Load patients without VOI

### DIFF
--- a/pytripgui/app_logic/app_callbacks.py
+++ b/pytripgui/app_logic/app_callbacks.py
@@ -184,7 +184,7 @@ class AppCallback:
 
     def open_voxelplan_callback(self, patient_item):
         path = self.parent_gui.browse_file_path("Open Voxelpan", "Voxelplan (*.hed)")
-        filename, extension = os.path.splitext(path)
+        filename, _ = os.path.splitext(path)
 
         if filename == "":
             return False

--- a/pytripgui/app_logic/app_callbacks.py
+++ b/pytripgui/app_logic/app_callbacks.py
@@ -256,6 +256,13 @@ class AppCallback:
             if state_item.state is None:
                 state_item.state = self.app_model.viewcanvases.get_gui_state()
 
+            # hide VOI list
+            if not data_item.data.vdx or not data_item.data.vdx.vois:
+                logger.debug("no VOI data present, hiding VOI list control")
+                self.app_model.viewcanvases.viewcanvas_view.vois_tree_empty(True)
+            else:
+                self.app_model.viewcanvases.viewcanvas_view.vois_tree_empty(False)
+
     def patient_tree_show(self):
         self.app_model.patient_tree.set_visible(self.parent_gui.action_open_tree_checked)
 

--- a/pytripgui/app_logic/app_callbacks.py
+++ b/pytripgui/app_logic/app_callbacks.py
@@ -191,7 +191,12 @@ class AppCallback:
 
         patient = patient_item.data
         patient.open_ctx(filename + ".ctx")  # Todo catch exceptions
-        patient.open_vdx(filename + ".vdx")  # Todo catch exceptions
+        try:
+            patient.open_vdx(filename + ".vdx")  # Todo catch more exceptions
+        except FileNotFoundError:
+            logger.warning("Loaded patient has no VOI data")
+            # TODO add empty vdx init if needed
+            patient.vdx = None
 
         if not self.app_model.viewcanvases:
             self.app_model.viewcanvases = ViewCanvases()

--- a/pytripgui/app_logic/app_callbacks.py
+++ b/pytripgui/app_logic/app_callbacks.py
@@ -259,9 +259,9 @@ class AppCallback:
             # hide VOI list
             if not data_item.data.vdx or not data_item.data.vdx.vois:
                 logger.debug("no VOI data present, hiding VOI list control")
-                self.app_model.viewcanvases.viewcanvas_view.vois_tree_empty(True)
+                self.app_model.viewcanvases.viewcanvas_view.voi_list_empty(True)
             else:
-                self.app_model.viewcanvases.viewcanvas_view.vois_tree_empty(False)
+                self.app_model.viewcanvases.viewcanvas_view.voi_list_empty(False)
 
     def patient_tree_show(self):
         self.app_model.patient_tree.set_visible(self.parent_gui.action_open_tree_checked)

--- a/pytripgui/canvas_vc/canvas_controller.py
+++ b/pytripgui/canvas_vc/canvas_controller.py
@@ -105,7 +105,7 @@ class CanvasController:
             self._model.set_ctx(patient.ctx)
             self._model.set_vdx()
 
-        if patient.vdx.vois:
+        if patient.vdx and patient.vdx.vois:
             self._ui.voi_list.event_callback = self._on_update_voi
             self._ui.voi_list.fill(patient.vdx.vois, lambda item: item.name)
             self._on_update_voi()

--- a/pytripgui/canvas_vc/canvas_view.py
+++ b/pytripgui/canvas_vc/canvas_view.py
@@ -141,3 +141,23 @@ class CanvasView:
         else:
             self._ui.voi_listWidget.hide()
             self._ui.voiList_checkBox.setCheckState(QtCore.Qt.Unchecked)
+
+    def vois_tree_empty(self, empty=True):
+        """
+        Method that handles displaying and hiding the VOI list and its checkBox.
+
+        Parameters:
+        empty(bool): Whether the list is empty and should be hidden.
+        """
+        voi_list = self._ui.voi_listWidget
+        checkbox = self._ui.voiList_checkBox
+
+        if empty:
+            voi_list.hide()
+            checkbox.hide()
+        else:
+            checkbox.show()
+            if checkbox.isChecked():
+                voi_list.show()
+            else:
+                voi_list.hide()

--- a/pytripgui/canvas_vc/canvas_view.py
+++ b/pytripgui/canvas_vc/canvas_view.py
@@ -27,11 +27,11 @@ class CanvasView:
         self._ui.updateGeometry()
 
         self._internal_events_setup()
-        self.voi_list_set_enabled(True)
+        self.voi_list_set_visibility(True)
 
     def _internal_events_setup(self):
 
-        self._ui.voiList_checkBox.stateChanged.connect(self.voi_list_set_enabled)
+        self._ui.voiList_checkBox.stateChanged.connect(self.voi_list_set_visibility)
 
         self._ui.perspective_comboBox.currentIndexChanged.connect(
             lambda index: self.internal_events.on_perspective_change())
@@ -134,8 +134,14 @@ class CanvasView:
     def _enable_perspective_selector(self):
         self._ui.perspective_comboBox.setEnabled(True)
 
-    def voi_list_set_enabled(self, state):
-        if state:
+    def voi_list_set_visibility(self, visible=True):
+        """
+        Method that handles displaying and hiding the VOI list.
+
+        Parameters:
+        visible(bool): Whether the list should be shown.
+        """
+        if visible:
             self._ui.voi_listWidget.show()
             self._ui.voiList_checkBox.setCheckState(QtCore.Qt.Checked)
         else:
@@ -144,7 +150,7 @@ class CanvasView:
 
     def voi_list_empty(self, empty=True):
         """
-        Method that handles displaying and hiding the VOI list and its checkBox.
+        Method that handles displaying and hiding the VOI list and its checkBox when VOI data is unavailable.
 
         Parameters:
         empty(bool): Whether the list is empty and should be hidden.

--- a/pytripgui/canvas_vc/canvas_view.py
+++ b/pytripgui/canvas_vc/canvas_view.py
@@ -27,11 +27,11 @@ class CanvasView:
         self._ui.updateGeometry()
 
         self._internal_events_setup()
-        self.vois_tree_set_enabled(True)
+        self.voi_list_set_enabled(True)
 
     def _internal_events_setup(self):
 
-        self._ui.voiList_checkBox.stateChanged.connect(self.vois_tree_set_enabled)
+        self._ui.voiList_checkBox.stateChanged.connect(self.voi_list_set_enabled)
 
         self._ui.perspective_comboBox.currentIndexChanged.connect(
             lambda index: self.internal_events.on_perspective_change())
@@ -134,7 +134,7 @@ class CanvasView:
     def _enable_perspective_selector(self):
         self._ui.perspective_comboBox.setEnabled(True)
 
-    def vois_tree_set_enabled(self, state):
+    def voi_list_set_enabled(self, state):
         if state:
             self._ui.voi_listWidget.show()
             self._ui.voiList_checkBox.setCheckState(QtCore.Qt.Checked)
@@ -142,7 +142,7 @@ class CanvasView:
             self._ui.voi_listWidget.hide()
             self._ui.voiList_checkBox.setCheckState(QtCore.Qt.Unchecked)
 
-    def vois_tree_empty(self, empty=True):
+    def voi_list_empty(self, empty=True):
         """
         Method that handles displaying and hiding the VOI list and its checkBox.
 

--- a/pytripgui/canvas_vc/canvas_view.py
+++ b/pytripgui/canvas_vc/canvas_view.py
@@ -27,7 +27,7 @@ class CanvasView:
         self._ui.updateGeometry()
 
         self._internal_events_setup()
-        self.voi_list_set_visibility(True)
+        self.voi_list_set_visibility(visible=True)
 
     def _internal_events_setup(self):
 
@@ -134,7 +134,7 @@ class CanvasView:
     def _enable_perspective_selector(self):
         self._ui.perspective_comboBox.setEnabled(True)
 
-    def voi_list_set_visibility(self, visible=True):
+    def voi_list_set_visibility(self, visible: bool = True) -> None:
         """
         Method that handles displaying and hiding the VOI list.
 
@@ -148,7 +148,7 @@ class CanvasView:
             self._ui.voi_listWidget.hide()
             self._ui.voiList_checkBox.setCheckState(QtCore.Qt.Unchecked)
 
-    def voi_list_empty(self, empty=True):
+    def voi_list_empty(self, empty: bool = True) -> None:
         """
         Method that handles displaying and hiding the VOI list and its checkBox when VOI data is unavailable.
 


### PR DESCRIPTION
Patients without VOI can now be loaded. When no VOI data is available, PatientModel.vdx is set to None.

Displaying patients has been tested, but further testing will be needed once adding VOI to an existing patient is possible.

Closes #445 