### PR TITLE
Executable on older Windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -58,7 +58,7 @@ build_script:
 # installer
 # generate single dir installation
 # add InnoSetup to PATH
-  - set PATH="C:\Program Files (x86)\Inno Setup 6";%PATH%star
+  - set PATH="C:\Program Files (x86)\Inno Setup 6";%PATH%
 # make windows installer
   - iscc win_innosetup.iss
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -58,7 +58,7 @@ build_script:
 # installer
 # generate single dir installation
 # add InnoSetup to PATH
-  - set PATH="C:\Program Files (x86)\Inno Setup 5";%PATH%
+  - set PATH="C:\Program Files (x86)\Inno Setup 6";%PATH%star
 # make windows installer
   - iscc win_innosetup.iss
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,6 @@
 # validation page for appveyor config: https://ci.appveyor.com/tools/validate-yaml
 
+# latest image with newer windows and python
 image: Visual Studio 2019
 
 # we are not building Visual Studio project, so default build step is off
@@ -7,7 +8,6 @@ build: off
 
 environment:
   matrix:
-
      - platform: x64
        PYTHON: "C:\\Python38-x64"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,7 @@
 # validation page for appveyor config: https://ci.appveyor.com/tools/validate-yaml
 
+image: Visual Studio 2019
+
 # we are not building Visual Studio project, so default build step is off
 build: off
 

--- a/main.spec
+++ b/main.spec
@@ -76,11 +76,9 @@ exclude = [
     "Qt5Svg.dll",
     "Qt5WebSockets.dll",
     "tcl86t.dll",
-    "tk86t.dll",
-    "ucrtbase.dll"
+    "tk86t.dll"
 ]
 exclude_startswith = [
-    "api-ms-win",
     "PyQt5\\Qt5\\plugins\\imageformats",
     "PyQt5\\Qt5\\plugins\\iconengines"
 ]


### PR DESCRIPTION
Older Windows e.g. Windows 7 needs api-ms-win-* and ucrtbase dlls that were missing.