### PR TITLE
Canvas slider fix

### DIFF
--- a/pytripgui/app_logic/app_callbacks.py
+++ b/pytripgui/app_logic/app_callbacks.py
@@ -225,7 +225,9 @@ class AppCallback:
             self.app_model.viewcanvases = ViewCanvases()
             self.parent_gui.add_widget(self.app_model.viewcanvases.widget())
 
-        self.app_model.viewcanvases.set_patient(patient)
+        # someone needs to test this, but I think it's unnecessary,
+        #   because after that callback another event is emitted, which sets patient one more time
+        # self.app_model.viewcanvases.set_patient(patient)
         return True
 
     def open_dicom_callback(self, patient_item):
@@ -244,7 +246,9 @@ class AppCallback:
             self.app_model.viewcanvases = ViewCanvases()
             self.parent_gui.add_widget(self.app_model.viewcanvases.widget())
 
-        self.app_model.viewcanvases.set_patient(patient)
+        # someone needs to test this, but I think it's unnecessary,
+        #   because after that callback another event is emitted, which sets patient one more time
+        # self.app_model.viewcanvases.set_patient(patient)
         return True
 
     def export_patient_voxelplan_callback(self, patient_item):

--- a/pytripgui/canvas_vc/canvas_controller.py
+++ b/pytripgui/canvas_vc/canvas_controller.py
@@ -10,7 +10,6 @@ class CanvasController:
     """
     This class holds all logic for plotting the canvas, which are shared among subclasses such as Ctx, Vdx etc.
     """
-
     def __init__(self, model, ui):
         self._model = model
         self._ui = ui

--- a/pytripgui/canvas_vc/canvas_view.py
+++ b/pytripgui/canvas_vc/canvas_view.py
@@ -79,6 +79,10 @@ class CanvasView:
         self._ui.perspective_comboBox.setCurrentIndex(index_of_element)
 
     def set_position_changed_callback(self, callback):
+        # event is emitted every time value od slider is changed, for example:
+        #   when slider value is set by controller
+        #   when user scrolls slider
+        #   when user stops dragging slider - thanks to disabled tracking
         self._ui.position_slider.valueChanged.connect(callback)
 
     def remove_position_changed_callback(self, callback):

--- a/pytripgui/canvas_vc/canvas_view.py
+++ b/pytripgui/canvas_vc/canvas_view.py
@@ -29,6 +29,9 @@ class CanvasView:
         self._internal_events_setup()
         self.voi_list_set_visibility(visible=True)
 
+        # "If tracking is disabled, the slider emits the valueChanged() signal only when the user releases the slider."
+        self._ui.position_slider.setTracking(False)
+
     def _internal_events_setup(self):
 
         self._ui.voiList_checkBox.stateChanged.connect(self.voi_list_set_visibility)
@@ -76,7 +79,10 @@ class CanvasView:
         self._ui.perspective_comboBox.setCurrentIndex(index_of_element)
 
     def set_position_changed_callback(self, callback):
-        self._ui.position_slider.sliderMoved.connect(callback)
+        self._ui.position_slider.valueChanged.connect(callback)
+
+    def remove_position_changed_callback(self, callback):
+        self._ui.position_slider.valueChanged.disconnect(callback)
 
     def plot_let(self, data):
         self._plotter.plot_let(data)


### PR DESCRIPTION
Changelog:
- fixed bug: set_patient was called two times when patient was added to tree
- fixed bug: creating plan was adding another slider listener, which caused crazy behaviour of it
- scrolling on canvas moves slider 1 position for each scroll "tick"
- scrolling on slider moves slider 5 positions for each scroll "tick"
- dragging slider emits event only when slider is realeased, every position beetwen pressing slider and releasing it is ignored

Closes:
- #427 
