### PR TITLE
Fix app crashing when patient's DICOM export is cancelled.

### DIFF
--- a/pytripgui/main_window_qt_vc/main_window_view.py
+++ b/pytripgui/main_window_qt_vc/main_window_view.py
@@ -59,11 +59,10 @@ class MainWindowQtView:
         dialog.setOptions(QFileDialog.ShowDirsOnly)
         dialog.exec_()
 
-        # only one directory can be selected in dialog window,
-        # but the selectedFiles method only returns a list, so [0] is selected
-        selected_path = dialog.selectedFiles()[0]
-
         if dialog.result() == QFileDialog.Accepted:
+            # only one directory can be selected in dialog window,
+            # but the selectedFiles method only returns a list, so [0] is selected
+            selected_path = dialog.selectedFiles()[0]
             return selected_path
         return ""
 


### PR DESCRIPTION
The app encountered an indexing error when directory selection was cancelled.

Closes #522 