### PR TITLE
Fixed plan execution from the context menu

### DIFF
--- a/pytripgui/app_logic/app_callbacks.py
+++ b/pytripgui/app_logic/app_callbacks.py
@@ -472,7 +472,7 @@ class AppCallback:
             self.parent_gui.action_create_plan_set_enable(True)
             self.parent_gui.action_create_field_set_enable(True)
             self._show_patient(top_item, item)
-        if self.is_executable(item):
+        if item.is_executable():
             self.parent_gui.action_execute_plan_set_enable(True)
 
     def _show_patient(self, data_item: PatientItem, state_item: PatientGuiState) -> None:
@@ -508,25 +508,3 @@ class AppCallback:
         None
         """
         self.app_model.patient_tree.set_visible(self.parent_gui.action_open_tree_checked)
-
-    @staticmethod
-    def is_executable(item: TreeItem) -> bool:
-        """
-        Assert whether an item on the patient tree can be executed.
-        Execution is possible on plans which have
-
-        Parameters:
-        item (TreeItem): The patient tree item in question.
-
-        Returns:
-        bool: Whether the item can be executed.
-        """
-        if isinstance(item, PlanItem):
-            # a plan which has children - fields
-            if item.has_children():
-                return True
-        elif isinstance(item, FieldItem):
-            # a field item belonging to a plan
-            return True
-        # not a plan or a plan without fields
-        return False

--- a/pytripgui/tree_vc/tree_items.py
+++ b/pytripgui/tree_vc/tree_items.py
@@ -58,6 +58,27 @@ class TreeItem(NodeMixin):
         children.remove(child)
         self.children = children
 
+    def is_executable(self) -> bool:
+        """
+        Assert whether an item on the patient tree can be executed.
+        Execution is possible on plans which have at least one field.
+
+        Parameters:
+        item (TreeItem): The patient tree item in question.
+
+        Returns:
+        bool: Whether the item can be executed.
+        """
+        if isinstance(self, PlanItem):
+            # a plan which has children - fields
+            if self.has_children():
+                return True
+        elif isinstance(self, FieldItem):
+            # a field item belonging to a plan
+            return True
+        # not a plan or a plan without fields
+        return False
+
 
 class PatientList(TreeItem):
     """

--- a/pytripgui/tree_vc/tree_view.py
+++ b/pytripgui/tree_vc/tree_view.py
@@ -63,7 +63,8 @@ class TreeView(QTreeView):
         elif isinstance(self.selected_item, PlanItem):
             popup_menu.addAction("Add new Field", self.internal_events.on_add_child)
             popup_menu.addSeparator()
-            popup_menu.addAction("Execute", self.internal_events.on_execute)
+            execute_action = popup_menu.addAction("Execute", self.internal_events.on_execute)
+            execute_action.setEnabled(self.selected_item.is_executable())
             popup_menu.addAction("Edit", self.internal_events.on_edit_selected_item)
             popup_menu.addAction("Delete", self.internal_events.on_delete)
         elif isinstance(self.selected_item, FieldItem):


### PR DESCRIPTION
Alternatively, we could also display a popup error saying that this plan has no fields.

fixes #526 