### PR TITLE
improve gui executor messages

### DIFF
--- a/pytripgui/app_logic/gui_executor.py
+++ b/pytripgui/app_logic/gui_executor.py
@@ -35,8 +35,8 @@ class GuiExecutor:
             self._ui.enable_ok_button()
             self.done = True
 
-        while not self._thread.std_out_queue.empty():
-            text = self._thread.std_out_queue.get(False)
+        while not self._thread.logger.empty():
+            text = self._thread.logger.get()
             self._ui.append_log(text)
 
     def start(self):

--- a/pytripgui/plan_executor/executor.py
+++ b/pytripgui/plan_executor/executor.py
@@ -43,7 +43,7 @@ class PlanExecutor:
             te.add_executor_logger(self.logger)
 
         try:
-            te.execute(plan)
+            te.execute(plan, use_default_logger=False)
         except BaseException as e:
             logger.error(e.__str__())
             sys.exit(-1)

--- a/pytripgui/plan_executor/executor.py
+++ b/pytripgui/plan_executor/executor.py
@@ -9,9 +9,9 @@ logger = logging.getLogger(__name__)
 
 
 class PlanExecutor:
-    def __init__(self, trip_config, listener=None):
+    def __init__(self, trip_config, logger=None):
         self.trip_config = trip_config
-        self.listener = listener
+        self.logger = logger
 
     def check_config(self):
         # TODO replace with function that actually runs trip, and collect returned errors
@@ -34,19 +34,17 @@ class PlanExecutor:
             te.servername = self.trip_config.host_name
             te.username = self.trip_config.user_name
             te.password = self.trip_config.password
-            print(self.trip_config.pkey_path)
             te.pkey_path = self.trip_config.pkey_path
             te.remote_base_dir = self.trip_config.wdir_remote_path + '/'
 
         te.trip_bin_path = self.trip_config.trip_path + '/' + 'TRiP98'
 
-        if self.listener:
-            te.add_log_listener(self.listener)
+        if self.logger:
+            te.add_executor_logger(self.logger)
 
         try:
             te.execute(plan)
         except BaseException as e:
-            self.listener.write(e.__str__())
             logger.error(e.__str__())
             sys.exit(-1)
 

--- a/pytripgui/plan_executor/html_executor_logger.py
+++ b/pytripgui/plan_executor/html_executor_logger.py
@@ -33,14 +33,15 @@ class HtmlExecutorLogger(ExecutorLogger):
         """ Changes '<' and '>' in tags to html entities
         """
         text = text.replace("<E>", "&lt;E&gt;")  # error
+        text = text.replace("<SYS>", "&lt;SYS&gt;")  # system
         text = text.replace("<I>", "&lt;I&gt;")  # info
         text = text.replace("<D>", "&lt;D&gt;")  # debug
         return text
 
     def _format_colors(self, text):
-        """ Changes lines with <E> from TRiP98 result to red color
+        """ Changes lines with <E> or <SYS> to red color
         """
-        if "&lt;E&gt;" in text:
+        if "&lt;E&gt;" in text or "&lt;SYS&gt;" in text:
             text = self._red_font.format(text)
         return text
 

--- a/pytripgui/plan_executor/html_executor_logger.py
+++ b/pytripgui/plan_executor/html_executor_logger.py
@@ -1,0 +1,43 @@
+
+from queue import Queue
+from pytrip.tripexecuter import ExecutorLogger
+
+
+class HtmlExecutorLogger(ExecutorLogger):
+    def __init__(self):
+        self.queue = Queue()
+
+    def info(self, text):
+        self.queue.put("<b>{}</b>".format(text))
+
+    def log(self, text):
+        text = self._format_tags(text)
+        text = self._format_ansi(text)
+        text = self._format_colors(text)
+        self.queue.put(text)
+
+    def error(self, text):
+        self.queue.put("<font color=\"Red\"><b>{}</b></font>".format(text))
+
+    def empty(self):
+        return self.queue.empty()
+
+    def get(self):
+        return self.queue.get(block=False)
+
+    def _format_tags(self, text):
+        text = text.replace("<E>", "&lt;E&gt;")  # error
+        text = text.replace("<I>", "&lt;I&gt;")  # info
+        text = text.replace("<D>", "&lt;D&gt;")  # debug
+        return text
+
+    def _format_colors(self, text):
+        if "&lt;E&gt;" in text:
+            text = "<font color=\"Red\">{}</font>".format(text)
+        return text
+
+    def _format_ansi(self, text):
+        """Remove ansi excape sequences
+        """
+        import re
+        return re.sub(r"\033\[[0-9]+m", "", text)

--- a/pytripgui/plan_executor/html_executor_logger.py
+++ b/pytripgui/plan_executor/html_executor_logger.py
@@ -5,39 +5,47 @@ from pytrip.tripexecuter import ExecutorLogger
 
 class HtmlExecutorLogger(ExecutorLogger):
     def __init__(self):
-        self.queue = Queue()
+        self._queue = Queue()
+
+        self._info_tag = "<b>{}</b>"  # bold
+        self._red_font = "<font color=\"Red\">{}</font>"
+        self._error_tag = self._red_font.format("<b>{}</b>")  # red and bold
 
     def info(self, text):
-        self.queue.put("<b>{}</b>".format(text))
+        self._queue.put(self._info_tag.format(text))
 
     def log(self, text):
         text = self._format_tags(text)
         text = self._format_ansi(text)
         text = self._format_colors(text)
-        self.queue.put(text)
+        self._queue.put(text)
 
     def error(self, text):
-        self.queue.put("<font color=\"Red\"><b>{}</b></font>".format(text))
+        self._queue.put(self._error_tag.format(text))
 
     def empty(self):
-        return self.queue.empty()
+        return self._queue.empty()
 
     def get(self):
-        return self.queue.get(block=False)
+        return self._queue.get(block=False)
 
     def _format_tags(self, text):
+        """ Changes '<' and '>' in tags to html entities
+        """
         text = text.replace("<E>", "&lt;E&gt;")  # error
         text = text.replace("<I>", "&lt;I&gt;")  # info
         text = text.replace("<D>", "&lt;D&gt;")  # debug
         return text
 
     def _format_colors(self, text):
+        """ Changes lines with <E> from TRiP98 result to red color
+        """
         if "&lt;E&gt;" in text:
-            text = "<font color=\"Red\">{}</font>".format(text)
+            text = self._red_font.format(text)
         return text
 
     def _format_ansi(self, text):
-        """Remove ansi excape sequences
+        """ Remove ansi escape sequences
         """
         import re
         return re.sub(r"\033\[[0-9]+m", "", text)

--- a/pytripgui/plan_executor/threaded_executor.py
+++ b/pytripgui/plan_executor/threaded_executor.py
@@ -1,13 +1,14 @@
 from threading import Thread
 from queue import Queue
 from pytripgui.plan_executor.executor import PlanExecutor
+from pytripgui.plan_executor.html_executor_logger import HtmlExecutorLogger
 
 
 class ThreadedExecutor(Thread):
     def __init__(self, plan, patient, trip_config):
         super().__init__()
 
-        self.std_out_queue = Queue()
+        self.logger = HtmlExecutorLogger()
         self.item_queue = Queue()
 
         self.patient = patient
@@ -23,9 +24,6 @@ class ThreadedExecutor(Thread):
             self.item_queue.put(sim_results)
 
     def _execute_plan(self, plan, patient):
-        plan_executor = PlanExecutor(self.trip_config, self)
+        plan_executor = PlanExecutor(self.trip_config, self.logger)
         item = plan_executor.execute(patient.data, plan.data)
         return item
-
-    def write(self, text):
-        self.std_out_queue.put(text)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pytrip98~=3.4  # use versions compatible with 3.4 (3.4 and later from 3.x series)
+pytrip98~=3.6  # use versions compatible with 3.6 (3.6 and later from 3.x series)
 PyQt5>=5.15  ; python_version >= '3.8'
 PyQt5<5.10 ; python_version < '3.8'
 PyQtChart>=5.15  ; python_version >= '3.8'

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ with open('README.rst') as readme_file:
 
 # install_requires is list of dependencies needed by pip when running `pip install`
 install_requires = [
-    'pytrip98~=3.4',
+    'pytrip98~=3.6',
     'anytree~=2.8',
     'paramiko~=2.7',
     'Events~=0.4',


### PR DESCRIPTION
adds better messages in GUI executor
uses HTML to style messages

needs this version of pytrip: https://github.com/pytrip/pytrip/pull/640

closes #365
closes #366
closes #510

![obraz](https://user-images.githubusercontent.com/24357718/142066657-ac330a14-52d9-4359-917a-9c5c2e861c92.png)
