### PR TITLE
Canvas fixes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,14 +1,14 @@
 Overview
 ========
 
-**pytripgui** is graphical user interface (GUI) built around TRiP98 planning system and pytrip package.
+**pytripgui** is the graphical user interface (GUI) built around TRiP98 planning system and pytrip package.
 It is capable of visualising patient CT data, dose and LET overlays.
-pytripgui can make treatment plans using local or remote TRiP98 package.
+pytripgui can make treatment plans using the local or remote TRiP98 package.
 
 TRiP98 package is not included here, if you need it, go first to TRiP98 webpage
 http://bio.gsi.de/DOCS/TRiP98/NEW/DOCS/trip98.html
 
-pytripgui works under most popular operating systems with necessary packages installed, see installation instructions below.
+pytripgui works under the most popular operating systems with necessary packages installed, see installation instructions below.
 
 Quick installation guide
 ------------------------

--- a/pytripgui/canvas_vc/objects/dos.py
+++ b/pytripgui/canvas_vc/objects/dos.py
@@ -27,28 +27,29 @@ class Dos(PlotDataBase):
         self.dos_scale = None
         self.min_dose = 0
         self.max_dose = None
+        self.factor = 1.0
+        self._max_dose_from_cube = None
 
     def prepare_data_to_plot(self):
         if not self.cube:
             return
 
+        if self._max_dose_from_cube is None:
+            self._max_dose_from_cube = np.amax(self.cube.cube)
+
         self.dos_scale = self._get_proposed_scale()
         self._set_aspect()
 
-        factor = None
         if self.dos_scale == DoseAxisType.abs:
-            factor = 1000 / self.cube.target_dose
-        if self.dos_scale == DoseAxisType.rel:
-            factor = 10
+            self.factor = 1000.0 / self.cube.target_dose
+        elif self.dos_scale == DoseAxisType.rel:
+            self.factor = 10.0
 
-        if factor is not None:
-            self.max_dose = np.amax(self.cube.cube) / float(factor)
-        else:
-            self.max_dose = np.amax(self.cube.cube)
+        self.max_dose = self._max_dose_from_cube / self.factor
 
         dos_data = self.projection_selector.get_projection(self.cube)
 
-        self.data_to_plot = dos_data / float(factor)
+        self.data_to_plot = dos_data / self.factor
         self.data_to_plot[self.data_to_plot <= self.min_dose] = self.min_dose
 
     def _get_proposed_scale(self):

--- a/pytripgui/canvas_vc/objects/let.py
+++ b/pytripgui/canvas_vc/objects/let.py
@@ -1,5 +1,7 @@
 import logging
 
+import numpy as np
+
 from pytripgui.canvas_vc.objects.data_base import PlotDataBase
 
 logger = logging.getLogger(__name__)
@@ -15,6 +17,9 @@ class Let(PlotDataBase):
     def prepare_data_to_plot(self):
         if self.cube is None:
             return
+
+        if self.max_let is None:
+            self.max_let = np.amax(self.cube.cube)
 
         self._set_aspect()
         self.data_to_plot = self.projection_selector.get_projection(self.cube)

--- a/pytripgui/canvas_vc/plotter/bars/bar_base.py
+++ b/pytripgui/canvas_vc/plotter/bars/bar_base.py
@@ -31,6 +31,7 @@ class BarBase(ABC, Axes):
         self.cb_fontsize = 8  # fontsize of colourbar labels
         self.label = 'DEFAULT_LABEL'
         self.bar = None
+        self.set_aspect(30)
 
     def plot_bar(self, data, **kwargs):
         """
@@ -40,6 +41,7 @@ class BarBase(ABC, Axes):
         cb.set_label(self.label, color=self.fg_color, fontsize=self.cb_fontsize)
         cb.outline.set_edgecolor(self.bg_color)
         cb.ax.yaxis.set_tick_params(color=self.fg_color)
+        cb.ax.yaxis.set_label_position('left')
         plt.setp(plt.getp(cb.ax.axes, 'yticklabels'), color=self.fg_color)
         cb.ax.yaxis.set_tick_params(color=self.fg_color, labelsize=self.cb_fontsize)
         self.bar = cb
@@ -49,3 +51,4 @@ class BarBase(ABC, Axes):
         Clears whole axes, removes bar.
         """
         self.cla()
+        self.remove()

--- a/pytripgui/canvas_vc/plotter/coordinate_info.py
+++ b/pytripgui/canvas_vc/plotter/coordinate_info.py
@@ -112,7 +112,7 @@ class CoordinateInfo(Axes3D):
         # initialize whole plot if necessary
         if not self._data_set:
             for plane in self._surfaces:
-                self._plot_plane(plane, current_slices, last_slices, False)
+                self._plot_plane(plane, current_slices, last_slices, plane == current_plane)
 
             self._data_set = True
 

--- a/pytripgui/canvas_vc/plotter/managers/plotting_manager.py
+++ b/pytripgui/canvas_vc/plotter/managers/plotting_manager.py
@@ -183,8 +183,7 @@ class PlottingManager:
             self.info_axes = self.figure.add_subplot(self.placement_manager.get_coord_info_place(),
                                                      projection=CoordinateInfo.name)
             self.blit_manager.add_artist(self.info_axes)
-        else:
-            self.info_axes.update_info(data)
+        self.info_axes.update_info(data)
 
     def plot_voi(self, vdx):
         self._voi_manager.plot_voi(vdx)

--- a/pytripgui/canvas_vc/plotter/mpl_plotter.py
+++ b/pytripgui/canvas_vc/plotter/mpl_plotter.py
@@ -29,7 +29,7 @@ class MplPlotter(FigureCanvas):
         if blit_manager will be created before figure is initialized
         dummy figure will be used and restoring background will work improperly
         """
-        self.figure: Figure = Figure(figsize=(width, height), dpi=dpi, tight_layout=True)
+        self.figure: Figure = Figure(figsize=(width, height), dpi=dpi, constrained_layout=True)
         self.blit_manager: BlitManager = BlitManager(self)
         self.plotting_manager: PlottingManager = PlottingManager(self.figure, self.blit_manager)
 


### PR DESCRIPTION
Fixed overlapping labels on canvas(#429), initial state of coordinate info (was empty), also bars are thinner now and have labels on the left side

Closes #429 
Closes #428 
- #429
- #428

![image](https://user-images.githubusercontent.com/44035398/145889092-6288bf79-95c7-4949-8657-27209a0f1cf6.png)
