### PR TITLE
installer improvements

### DIFF
--- a/win_innosetup.iss
+++ b/win_innosetup.iss
@@ -21,25 +21,25 @@ AppPublisher={#MyAppPublisher}
 AppPublisherURL={#MyAppURL}
 AppSupportURL={#MyAppURL}
 AppUpdatesURL={#MyAppURL}
-DefaultDirName={pf}\{#MyAppName}
+ArchitecturesAllowed=x64
+ArchitecturesInstallIn64BitMode=x64
+DefaultDirName={autopf}\{#MyAppName}
 DisableProgramGroupPage=yes
 OutputBaseFilename={#MyAppName}_{#MyAppVersion}_{#MyAppPlatform}_setup
 Compression=lzma
 SolidCompression=yes
 PrivilegesRequired=lowest
+PrivilegesRequiredOverridesAllowed=dialog
 LicenseFile={#SourcePath}\GPL_LICENSE.txt
 UninstallDisplayName=pytripgui
 VersionInfoVersion=0.1.0
 
 [Icons]
-Name: "{commonprograms}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"
-Name: "{commondesktop}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; Tasks: desktopicon
-
-[Languages]
-Name: "english"; MessagesFile: "compiler:Default.isl"
+Name: "{autoprograms}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"
+Name: "{autodesktop}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; Tasks: desktopicon
 
 [Tasks]
-Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked
+Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"
 
 [Run]
 Filename: "{app}\{#MyAppExeName}"; Description: "{cm:LaunchProgram,{#StringChange(MyAppName, '&', '&&')}}"; Flags: nowait postinstall skipifsilent
@@ -49,9 +49,14 @@ Source: "{#MyAppDir}{#MyAppExeName}"; DestDir: "{app}"; Flags: ignoreversion
 Source: "{#MyAppDir}*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
 ; NOTE: Don't use "Flags: ignoreversion" on any shared system files
 
+[Languages]
+Name: "english"; MessagesFile: "compiler:Default.isl"
 
-// https://stackoverflow.com/questions/2000296/inno-setup-how-to-automatically-uninstall-previous-installed-version/2099805#2099805
+[Messages]
+ErrorCreatingDir=Setup was unable to create the directory "%1". If you want to install this application in this location, run the installer as administrator
+
 [Code]
+// https://stackoverflow.com/questions/2000296/inno-setup-how-to-automatically-uninstall-previous-installed-version/2099805#2099805
 /////////////////////////////////////////////////////////////////////
 function GetUninstallString(): String;
 var

--- a/win_innosetup.iss
+++ b/win_innosetup.iss
@@ -23,6 +23,9 @@ AppSupportURL={#MyAppURL}
 AppUpdatesURL={#MyAppURL}
 ArchitecturesAllowed=x64
 ArchitecturesInstallIn64BitMode=x64
+; auto - depending on install mode it will be 'common' (admin mode) or 'user' (non-admin mode)
+; pf - Program Files
+; commonpf and userpf consts expand to different paths that user has access to
 DefaultDirName={autopf}\{#MyAppName}
 DisableProgramGroupPage=yes
 OutputBaseFilename={#MyAppName}_{#MyAppVersion}_{#MyAppPlatform}_setup


### PR DESCRIPTION
- fixed "access denied" error on non-admin installation when it wanted to create shortcuts (it showed always when installing as non-admin)
- better message on "access denied"  (it shows only when installing as non-admin to location that requires admin access)
- added dialog with install mode selection (non-admin and admin)
- set architecture to x64
- checkbox "Create a desktop shortcut" is now selected by default