### PR TITLE
Requirements hotfix and changes related to pytrip#628

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,7 +34,7 @@ install:
   - python -c "import struct;print(8 * struct.calcsize('P'))"
 # install usual requirements
   - python -m pip install --upgrade setuptools
-  - python -m pip install --upgrade -r requirements.txt
+  - python -m pip install -r requirements.txt
   - pip list
 # check numpy version
   - python -c "import numpy as np;print(np.version.version)"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,8 @@
-pytrip98~=3.6  # use versions compatible with 3.6 (3.6 and later from 3.x series)
+matplotlib==3.4.3  # remove once compatibility problem with matplotlib 3.5+ is restored
+pytrip98[remote]~=3.6  # use versions compatible with 3.6 (3.6 and later from 3.x series)
 PyQt5>=5.15  ; python_version >= '3.8'
 PyQt5<5.10 ; python_version < '3.8'
 PyQtChart>=5.15  ; python_version >= '3.8'
 PyQtChart<5.10 ; python_version < '3.8'
 anytree~=2.8
 Events~=0.4
-cryptography==3.2.1 ; python_version < '3.8'
-paramiko~=2.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-matplotlib==3.4.3 ; python_version >= 3.7 # remove once compatibility problem with matplotlib 3.5+ is restored
+matplotlib==3.4.3 ; python_version >= '3.7' # remove once compatibility problem with matplotlib 3.5+ is restored
 pytrip98[remote]~=3.6  # use versions compatible with 3.6 (3.6 and later from 3.x series)
 PyQt5>=5.15  ; python_version >= '3.8'
 PyQt5<5.10 ; python_version < '3.8'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-matplotlib==3.4.3  # remove once compatibility problem with matplotlib 3.5+ is restored
+matplotlib==3.4.3 ; python_version >= 3.7 # remove once compatibility problem with matplotlib 3.5+ is restored
 pytrip98[remote]~=3.6  # use versions compatible with 3.6 (3.6 and later from 3.x series)
 PyQt5>=5.15  ; python_version >= '3.8'
 PyQt5<5.10 ; python_version < '3.8'

--- a/setup.py
+++ b/setup.py
@@ -23,9 +23,9 @@ with open('README.rst') as readme_file:
 
 # install_requires is list of dependencies needed by pip when running `pip install`
 install_requires = [
-    'pytrip98~=3.6',
+    "matplotlib==3.4.3 ; python_version>='3.7'",
+    'pytrip98[remote]~=3.6',
     'anytree~=2.8',
-    'paramiko~=2.8',
     'Events~=0.4',
     "PyQt5<5.10 ; python_version<'3.8'",
     "PyQt5>=5.15 ; python_version>='3.8'",


### PR DESCRIPTION
Temporarily froze matplotlib at version 3.4.3.
Added extra dependency [remote] to pytrip.
Removed paramiko and cryptography as dependencies, as they are included in pytrip98[remote]. 

related to pytrip/pytrip#628

Hotfixes #554 