### PR TITLE
App icon setting

### DIFF
--- a/pytripgui/add_vois_vc/add_vois_cont.py
+++ b/pytripgui/add_vois_vc/add_vois_cont.py
@@ -35,7 +35,7 @@ class AddVOIsController:
         self.view.accept()
 
     def _create_add_voi_dialog(self) -> None:
-        view = AddSingleVOIQtView()
+        view = AddSingleVOIQtView(self.view.ui)
 
         # get VOI names that are already being used by the about to be added VOIs
         list_vois = self.view.voi_scroll_area.widget().layout()

--- a/pytripgui/add_vois_vc/add_vois_view.py
+++ b/pytripgui/add_vois_vc/add_vois_view.py
@@ -10,37 +10,37 @@ class AddVOIsQtView:
     """
     """
     def __init__(self, parent=None):
-        self._ui = AddVOIsDialog(parent)
-        self.name = Label(self._ui.name_label)
-        self.width = Label(self._ui.width_label)
-        self.height = Label(self._ui.height_label)
-        self.depth = Label(self._ui.depth_label)
-        self.pixel_size = Label(self._ui.pixelSize_label)
-        self.pixel_number_x = Label(self._ui.pixelNumberX_label)
-        self.pixel_number_y = Label(self._ui.pixelNumberY_label)
-        self.slice_number = Label(self._ui.sliceNumber_label)
-        self.slice_distance = Label(self._ui.sliceDistance_label)
-        self.x_offset = Label(self._ui.xOffset_label)
-        self.y_offset = Label(self._ui.yOffset_label)
-        self.slice_offset = Label(self._ui.sliceOffset_label)
+        self.ui = AddVOIsDialog(parent)
+        self.name = Label(self.ui.name_label)
+        self.width = Label(self.ui.width_label)
+        self.height = Label(self.ui.height_label)
+        self.depth = Label(self.ui.depth_label)
+        self.pixel_size = Label(self.ui.pixelSize_label)
+        self.pixel_number_x = Label(self.ui.pixelNumberX_label)
+        self.pixel_number_y = Label(self.ui.pixelNumberY_label)
+        self.slice_number = Label(self.ui.sliceNumber_label)
+        self.slice_distance = Label(self.ui.sliceDistance_label)
+        self.x_offset = Label(self.ui.xOffset_label)
+        self.y_offset = Label(self.ui.yOffset_label)
+        self.slice_offset = Label(self.ui.sliceOffset_label)
 
-        self.x_min = Label(self._ui.xMin_label)
-        self.x_max = Label(self._ui.xMax_label)
-        self.y_min = Label(self._ui.yMin_label)
-        self.y_max = Label(self._ui.yMax_label)
-        self.z_min = Label(self._ui.zMin_label)
-        self.z_max = Label(self._ui.zMax_label)
+        self.x_min = Label(self.ui.xMin_label)
+        self.x_max = Label(self.ui.xMax_label)
+        self.y_min = Label(self.ui.yMin_label)
+        self.y_max = Label(self.ui.yMax_label)
+        self.z_min = Label(self.ui.zMin_label)
+        self.z_max = Label(self.ui.zMax_label)
 
-        self.voi_scroll_area = self._ui.voi_scrollArea
+        self.voi_scroll_area = self.ui.voi_scrollArea
 
-        self.add_voi_button = PushButton(self._ui.addVOI_pushButton)
+        self.add_voi_button = PushButton(self.ui.addVOI_pushButton)
 
-        self.accept = self._ui.accept
-        self.accept_buttons = self._ui.accept_buttonBox
+        self.accept = self.ui.accept
+        self.accept_buttons = self.ui.accept_buttonBox
 
     def show(self) -> None:
-        self._ui.show()
-        self._ui.exec_()
+        self.ui.show()
+        self.ui.exec_()
 
     def exit(self) -> None:
-        self._ui.close()
+        self.ui.close()

--- a/pytripgui/config_vc/config_view.py
+++ b/pytripgui/config_vc/config_view.py
@@ -12,8 +12,8 @@ class ConfigQtView:
     stackedWidget_remote_index = 1
     """
     """
-    def __init__(self):
-        self._ui = UiTripConfig()
+    def __init__(self, parent=None):
+        self._ui = UiTripConfig(parent)
 
         self.name = LineEdit(self._ui.configName_lineEdit)
         self.user_name = LineEdit(self._ui.username_lineEdit)

--- a/pytripgui/kernel_vc/kernel_view.py
+++ b/pytripgui/kernel_vc/kernel_view.py
@@ -11,8 +11,8 @@ logger = logging.getLogger(__name__)
 class KernelQtView:
     """
     """
-    def __init__(self):
-        self.ui = UiKernelDialog()
+    def __init__(self, parent=None):
+        self.ui = UiKernelDialog(parent)
 
         self._setup_internal_callbacks()
         self._disable_unimplemented()

--- a/pytripgui/main.py
+++ b/pytripgui/main.py
@@ -2,6 +2,7 @@ import argparse
 import logging
 import sys
 
+from PyQt5.QtGui import QIcon
 from PyQt5.QtWidgets import QApplication
 
 from pytripgui.main_window_qt_vc.main_window_view import MainWindowQtView
@@ -43,6 +44,7 @@ def main(args=None):
     # all these objects need to be saved as variables, otherwise they will be garbage collected before app execution
     app = QApplication(sys.argv)
     view = MainWindowQtView()
+    view.ui.setWindowIcon(QIcon('res/icon.ico'))
     model = MainModel()
     controller = MainWindowController(model, view)
 

--- a/pytripgui/main_window_qt_vc/main_window_view.py
+++ b/pytripgui/main_window_qt_vc/main_window_view.py
@@ -22,13 +22,11 @@ class MainWindowQtView:
     def add_widget(self, widget):
         self.ui.main_layout.addWidget(widget)
 
-    @staticmethod
-    def get_trip_config_view():
-        return ConfigQtView()
+    def get_trip_config_view(self):
+        return ConfigQtView(self.ui)
 
-    @staticmethod
-    def get_kernel_config_view():
-        return KernelQtView()
+    def get_kernel_config_view(self):
+        return KernelQtView(self.ui)
 
     def browse_file_path(self, name, extension, path=None):
         """

--- a/pytripgui/view/qt_gui.py
+++ b/pytripgui/view/qt_gui.py
@@ -8,7 +8,7 @@ current_directory = os.path.dirname(os.path.realpath(__file__))
 
 
 class UiTripConfig(QtWidgets.QDialog):
-    def __init__(self, parent):
+    def __init__(self, parent=None):
         super(UiTripConfig, self).__init__(parent)
         ui_path = os.path.join(current_directory, 'trip_config.ui')
         uic.loadUi(ui_path, self)

--- a/pytripgui/view/qt_gui.py
+++ b/pytripgui/view/qt_gui.py
@@ -8,8 +8,8 @@ current_directory = os.path.dirname(os.path.realpath(__file__))
 
 
 class UiTripConfig(QtWidgets.QDialog):
-    def __init__(self):
-        super(UiTripConfig, self).__init__()
+    def __init__(self, parent):
+        super(UiTripConfig, self).__init__(parent)
         ui_path = os.path.join(current_directory, 'trip_config.ui')
         uic.loadUi(ui_path, self)
 
@@ -36,8 +36,8 @@ class UiExecuteConfigDialog(QtWidgets.QDialog):
 
 
 class UiKernelDialog(QtWidgets.QDialog):
-    def __init__(self):
-        super(UiKernelDialog, self).__init__()
+    def __init__(self, parent=None):
+        super(UiKernelDialog, self).__init__(parent)
         ui_path = os.path.join(current_directory, 'kernel.ui')
         uic.loadUi(ui_path, self)
 


### PR DESCRIPTION
App icon added. Works for all windows.

For the TRiP config, beam kernel setup and adding single VOIs windows, parent UIs needed to be set to inherit the icon from the main window.

closes #570 

* #570 