### PR TITLE
Contouring popup won't be displayed for patients without VOIs

### DIFF
--- a/pytripgui/app_logic/app_callbacks.py
+++ b/pytripgui/app_logic/app_callbacks.py
@@ -96,9 +96,10 @@ class AppCallback:
 
     def show_contouring_dialog(self):
         patient: PatientItem = self.app_model.patient_tree.selected_item_patient()
-        vois: Collection[Voi] = patient.data.vdx.vois
-        contouring_dialog: ContouringController = ContouringController(vois=vois, parent=self.parent_gui.ui)
-        contouring_dialog.show()
+        if patient.data.vdx:
+            vois: Collection[Voi] = patient.data.vdx.vois
+            contouring_dialog: ContouringController = ContouringController(vois=vois, parent=self.parent_gui.ui)
+            contouring_dialog.show()
 
     def on_execute_selected_plan(self) -> None:
         """


### PR DESCRIPTION
Added a condition for displaying the contouring popup that checks if the loaded patient has VDX data.