### PR TITLE
Refactor GitHub Actions workflow and update dependencies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Python application
+name: Tests
 
 on:
   push:
@@ -13,35 +13,39 @@ on:
 jobs:
   smoke_test:
     if: "!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]')"
-    runs-on: ubuntu-latest        
+    runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
 
     - name: Set up Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@v5
       with:
-        python-version: 3.9
+        python-version: '3.9'
+        cache: 'pip'
 
-    - name: Install dependencies
+    - name: Install system dependencies (Linux)
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0
+
+    - name: Install Python dependencies
       run: |
         python -m pip install --upgrade pip
         pip install -e ".[test]"
-        sudo apt install -y libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0
 
     - name: Smoke tests
       env:
-        QT_DEBUG_PLUGINS: 1
         DISPLAY: ':99.0'
-      run: |         
-        ulimit -c unlimited
-        xvfb-run --auto-servernum python -m pytest tests
-         
-         
+      run: |
+        xvfb-run --auto-servernum python -m pytest tests -q
+
+
   normal_test:
     if: "!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]')"
     strategy:
+      fail-fast: false
       matrix:
         python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
         platform: [ubuntu-latest, windows-latest]
@@ -50,36 +54,37 @@ jobs:
     needs: [smoke_test]
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
 
     - name: Set up Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
+        cache: 'pip'
 
-    - name: Install dependencies
+    - name: Install Python dependencies
       run: |
         python -m pip install --upgrade pip
         pip install -e ".[test]"
 
-    - name: Install dependencies (Linux)
-      if: ${{ runner.os == 'Linux' }}      
+    - name: Install system dependencies (Linux)
+      if: ${{ runner.os == 'Linux' }}
       run: |
-        sudo apt install -y libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0
+        sudo apt-get update
+        sudo apt-get install -y libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0
 
     - name: Regular test (Linux)
-      if: ${{ runner.os == 'Linux' }}      
+      if: ${{ runner.os == 'Linux' }}
       env:
         DISPLAY: ':99.0'
-      run: |         
-        ulimit -c unlimited
-        xvfb-run --auto-servernum python -m pytest tests/
+      run: |
+        xvfb-run --auto-servernum python -m pytest tests -q
 
     - name: Regular test (Windows)
-      if: ${{ runner.os == 'Windows' }}      
+      if: ${{ runner.os == 'Windows' }}
       env:
         QT_DEBUG_PLUGINS: 1
-      run: |         
-        pytest tests/
+      run: |
+        python -m pytest tests -q

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,17 +45,17 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
-    "pytest>=6.0",
-    "pytest-cov>=2.10",
+    "pytest>=8.2",
+    "pytest-cov>=4.1",
     "sphinx>=3.0",
     "sphinx-rtd-theme>=0.5",
     "flake8>=3.8",
     "pycodestyle>=2.6",
 ]
 test = [
-    "pytest>=6.0",
-    "pytest-qt>=4.0",
-    "pyautogui",
+    "pytest>=8.2",
+    "pytest-qt>=4.3",
+    "pytest-xvfb>=2.0 ; sys_platform == 'linux'",
 ]
 docs = [
     "sphinx>=3.0",
@@ -85,6 +85,7 @@ pytripgui = ["res/*", "view/*.ui", "VERSION"]
 [tool.pytest.ini_options]
 log_cli = true
 testpaths = ["tests"]
+qt_api = "pyqt5"
 
 [tool.setuptools_scm]
 version_scheme = "post-release"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,0 @@
-[pytest]
-log_cli = true

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,14 @@
+import os
+import platform
+
+import matplotlib
+import pytest
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _headless_qt_env():
+    """Ensure tests run without a visible display."""
+    if platform.system() == "Linux":
+        os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    os.environ.setdefault("MPLBACKEND", "Agg")
+    matplotlib.use(os.environ["MPLBACKEND"])


### PR DESCRIPTION
- Rename workflow from "Python application" to "Tests"
- Update actions/checkout and actions/setup-python versions
- Install system dependencies separately in the workflow
- Update pytest and pytest-cov versions in pyproject.toml
- Remove deprecated pytest.ini file
- Add conftest.py for headless Qt environment setup
- Refactor test_open_voxelplan to use monkeypatch instead of pyautogui