### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,10 @@ on:
   release:
     types: [published]
     
-    
+
+permissions:
+  contents: read
+
 jobs:
   smoke_test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/pytrip/pytripgui/security/code-scanning/2](https://github.com/pytrip/pytripgui/security/code-scanning/2)

To fix the issue, we should explicitly set workflow or job permissions to the minimum required. The best way is to add a `permissions` block at the workflow level (before `jobs:`), thereby constraining all jobs unless a child job sets its own override. Since all jobs shown (smoke_test, normal_test) only require read access to repository contents (for checkout and testing), the least-privilege value is:

```yaml
permissions:
  contents: read
```

This block should be inserted after the workflow name and triggers, but before the `jobs:` block, i.e., after line 11 (before line 13) in the provided snippet.

No other code change or dependency is required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
