### PR TITLE
Bump pytrip98[remote] dependency version from 3.10.1 to 3.10.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ classifiers = [
 ]
 dependencies = [
     "matplotlib>=3.8.4",
-    "pytrip98[remote]>=3.10.1",
+    "pytrip98[remote]>=3.10.2",
     "anytree>=2.8",
     "Events>=0.4",
     "PyQt5>=5.15",


### PR DESCRIPTION
This pull request makes a minor update to the `pytrip98` dependency in the `pyproject.toml` file, increasing the minimum required version from 3.10.1 to 3.10.2. This ensures that the project uses the latest bug fixes or features from `pytrip98`.